### PR TITLE
Replace TracerAggregator with decorator pattern for SlowBlockTracer

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -48,7 +48,6 @@ import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.worldview.BonsaiWorld
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.worldview.BonsaiWorldStateUpdateAccumulator;
 import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
-import org.hyperledger.besu.evm.tracing.TracerAggregator;
 import org.hyperledger.besu.evm.worldstate.StackedUpdater;
 import org.hyperledger.besu.evm.worldstate.WorldState;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
@@ -158,15 +157,17 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
   }
 
   /**
-   * Creates a SlowBlockTracer if slow block logging is enabled.
+   * Creates a SlowBlockTracer wrapping the given delegate if slow block logging is enabled.
    *
    * @param protocolContext the protocol context
+   * @param delegate the tracer to delegate to after slow block processing
    * @return an Optional containing the SlowBlockTracer if enabled, empty otherwise
    */
-  private Optional<SlowBlockTracer> getSlowBlockTracer(final ProtocolContext protocolContext) {
+  private Optional<SlowBlockTracer> getSlowBlockTracer(
+      final ProtocolContext protocolContext, final OperationTracer delegate) {
     final long slowBlockThresholdMs = protocolContext.getSlowBlockThresholdMs();
     if (slowBlockThresholdMs >= 0) {
-      return Optional.of(new SlowBlockTracer(slowBlockThresholdMs));
+      return Optional.of(new SlowBlockTracer(slowBlockThresholdMs, delegate));
     }
     return Optional.empty();
   }
@@ -247,12 +248,13 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
 
     final BlockAwareOperationTracer blockTracer =
         getBlockImportTracer(protocolContext, blockHeader);
-    final Optional<SlowBlockTracer> maybeSlowBlockTracer = getSlowBlockTracer(protocolContext);
 
-    // Compose operation-level tracer: base tracer + slow block tracer (if enabled)
-    final OperationTracer operationTracer =
-        maybeSlowBlockTracer
-            .<OperationTracer>map(sbt -> TracerAggregator.of(blockTracer, sbt))
+    // Compose operation-level tracer: when slow block tracing is enabled, SlowBlockTracer wraps
+    // the block import tracer as a delegate (decorator pattern) for monomorphic JIT dispatch.
+    // When disabled, use the block import tracer directly.
+    final BlockAwareOperationTracer composedTracer =
+        getSlowBlockTracer(protocolContext, blockTracer)
+            .<BlockAwareOperationTracer>map(sbt -> sbt)
             .orElse(blockTracer);
 
     final Address miningBeneficiary = miningBeneficiaryCalculator.calculateBeneficiary(blockHeader);
@@ -260,10 +262,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     LOG.trace(
         "traceStartBlock for {} using tracer {}",
         blockHeader.getNumber(),
-        blockTracer.getClass().getSimpleName());
-    blockTracer.traceStartBlock(worldState, blockHeader, miningBeneficiary);
-    maybeSlowBlockTracer.ifPresent(
-        sbt -> sbt.traceStartBlock(worldState, blockHeader, miningBeneficiary));
+        composedTracer.getClass().getSimpleName());
+    composedTracer.traceStartBlock(worldState, blockHeader, miningBeneficiary);
 
     final StateRootCommitter stateRootCommitter =
         blockProcessingMetrics.wrapStateRootCommitter(
@@ -286,7 +286,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
               worldState,
               protocolSpec,
               blockHashLookup,
-              operationTracer,
+              composedTracer,
               blockAccessListBuilder);
       protocolSpec
           .getPreExecutionProcessor()
@@ -569,9 +569,10 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       }
 
       LOG.trace("traceEndBlock for {}", blockHeader.getNumber());
-      // Call SlowBlockTracer first so it can collect metrics before state cleanup
-      maybeSlowBlockTracer.ifPresent(sbt -> sbt.traceEndBlock(blockHeader, blockBody));
-      blockTracer.traceEndBlock(blockHeader, blockBody);
+      // composedTracer handles the full traceEndBlock lifecycle: SlowBlockTracer collects metrics
+      // first then delegates to the block import tracer; when absent, the block import tracer is
+      // called directly.
+      composedTracer.traceEndBlock(blockHeader, blockBody);
 
       return new BlockProcessingResult(
           Optional.of(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/SlowBlockTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/SlowBlockTracer.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.tracing.EVMExecutionMetricsTracer;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldView;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
@@ -57,6 +58,7 @@ public class SlowBlockTracer implements BlockAwareOperationTracer {
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   private final long slowBlockThresholdMs;
+  private final OperationTracer delegate;
   private ExecutionStats executionStats;
   private EVMExecutionMetricsTracer metricsTracer;
 
@@ -68,7 +70,39 @@ public class SlowBlockTracer implements BlockAwareOperationTracer {
    *     logs all blocks.
    */
   public SlowBlockTracer(final long slowBlockThresholdMs) {
+    this(slowBlockThresholdMs, OperationTracer.NO_TRACING);
+  }
+
+  /**
+   * Creates a new SlowBlockTracer with a delegate tracer. The delegate receives all tracer calls
+   * after SlowBlockTracer has processed them, enabling a decorator/delegate chain that avoids
+   * megamorphic dispatch in the EVM hot loop.
+   *
+   * @param slowBlockThresholdMs the threshold in milliseconds beyond which blocks are logged. Zero
+   *     logs all blocks.
+   * @param delegate the tracer to delegate all calls to after processing
+   */
+  public SlowBlockTracer(final long slowBlockThresholdMs, final OperationTracer delegate) {
     this.slowBlockThresholdMs = slowBlockThresholdMs;
+    this.delegate = delegate != null ? delegate : OperationTracer.NO_TRACING;
+  }
+
+  /**
+   * Gets the delegate tracer.
+   *
+   * @return the delegate tracer, or {@link OperationTracer#NO_TRACING} if none
+   */
+  public OperationTracer getDelegate() {
+    return delegate;
+  }
+
+  /**
+   * Gets the slow block threshold in milliseconds.
+   *
+   * @return the threshold in milliseconds
+   */
+  public long getSlowBlockThresholdMs() {
+    return slowBlockThresholdMs;
   }
 
   @Override
@@ -88,6 +122,10 @@ public class SlowBlockTracer implements BlockAwareOperationTracer {
 
     // Create EVMExecutionMetricsTracer for this block
     metricsTracer = new EVMExecutionMetricsTracer();
+
+    if (delegate instanceof BlockAwareOperationTracer bat) {
+      bat.traceStartBlock(worldView, blockHeader, blockBody, miningBeneficiary);
+    }
   }
 
   @Override
@@ -106,6 +144,10 @@ public class SlowBlockTracer implements BlockAwareOperationTracer {
 
     // Create EVMExecutionMetricsTracer for this block
     metricsTracer = new EVMExecutionMetricsTracer();
+
+    if (delegate instanceof BlockAwareOperationTracer bat) {
+      bat.traceStartBlock(worldView, processableBlockHeader, miningBeneficiary);
+    }
   }
 
   @Override
@@ -120,6 +162,10 @@ public class SlowBlockTracer implements BlockAwareOperationTracer {
       final long timeNs) {
     executionStats.incrementTransactionCount();
     executionStats.addGasUsed(gasUsed);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.traceEndTransaction(
+          worldView, tx, status, output, logs, gasUsed, selfDestructs, timeNs);
+    }
   }
 
   @Override
@@ -141,6 +187,9 @@ public class SlowBlockTracer implements BlockAwareOperationTracer {
       ExecutionStatsHolder.clear();
       executionStats = null;
       metricsTracer = null;
+    }
+    if (delegate instanceof BlockAwareOperationTracer bat) {
+      bat.traceEndBlock(blockHeader, blockBody);
     }
   }
 
@@ -165,54 +214,84 @@ public class SlowBlockTracer implements BlockAwareOperationTracer {
   @Override
   public void tracePreExecution(final MessageFrame frame) {
     metricsTracer.tracePreExecution(frame);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.tracePreExecution(frame);
+    }
   }
 
   @Override
   public void tracePostExecution(final MessageFrame frame, final OperationResult operationResult) {
     metricsTracer.tracePostExecution(frame, operationResult);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.tracePostExecution(frame, operationResult);
+    }
   }
 
   @Override
   public void tracePrecompileCall(
       final MessageFrame frame, final long gasRequirement, final Bytes output) {
     metricsTracer.tracePrecompileCall(frame, gasRequirement, output);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.tracePrecompileCall(frame, gasRequirement, output);
+    }
   }
 
   @Override
   public void traceAccountCreationResult(
       final MessageFrame frame, final Optional<ExceptionalHaltReason> haltReason) {
     metricsTracer.traceAccountCreationResult(frame, haltReason);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.traceAccountCreationResult(frame, haltReason);
+    }
   }
 
   @Override
   public void tracePrepareTransaction(final WorldView worldView, final Transaction transaction) {
     metricsTracer.tracePrepareTransaction(worldView, transaction);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.tracePrepareTransaction(worldView, transaction);
+    }
   }
 
   @Override
   public void traceStartTransaction(final WorldView worldView, final Transaction transaction) {
     metricsTracer.traceStartTransaction(worldView, transaction);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.traceStartTransaction(worldView, transaction);
+    }
   }
 
   @Override
   public void traceBeforeRewardTransaction(
       final WorldView worldView, final Transaction tx, final Wei miningReward) {
     metricsTracer.traceBeforeRewardTransaction(worldView, tx, miningReward);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.traceBeforeRewardTransaction(worldView, tx, miningReward);
+    }
   }
 
   @Override
   public void traceContextEnter(final MessageFrame frame) {
     metricsTracer.traceContextEnter(frame);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.traceContextEnter(frame);
+    }
   }
 
   @Override
   public void traceContextReEnter(final MessageFrame frame) {
     metricsTracer.traceContextReEnter(frame);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.traceContextReEnter(frame);
+    }
   }
 
   @Override
   public void traceContextExit(final MessageFrame frame) {
     metricsTracer.traceContextExit(frame);
+    if (delegate != OperationTracer.NO_TRACING) {
+      delegate.traceContextExit(frame);
+    }
   }
 
   @Override


### PR DESCRIPTION
Built on https://github.com/besu-eth/besu/pull/9834

TracerAggregator causes megamorphic virtual dispatch in the EVM hot loop when combining SlowBlockTracer with a plugin block import tracer. The JIT cannot inline virtual calls when multiple concrete types flow through the same loop call site on every opcode execution.

SlowBlockTracer now accepts an optional delegate OperationTracer, forming a decorator chain where each call site sees exactly one concrete type, enabling the JIT to inline and speculate. The common case (no plugin tracer, delegate == NO_TRACING) adds only a single reference comparison per hot-path method with no extra dispatch.

AbstractBlockProcessor updated to construct SlowBlockTracer(threshold, blockTracer) directly instead of wrapping both in a TracerAggregator, and calls traceStartBlock/traceEndBlock once on the composed tracer.


## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/besu-eth/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
- [ ] hive tests: [Engine or other RPCs modified?](https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156302/Using+Hive+Test+Suite)


